### PR TITLE
Refactor zgpu to align with new WebGPU API

### DIFF
--- a/zig-gamedev-zgpu-dawn-update/src/wgpu.zig
+++ b/zig-gamedev-zgpu-dawn-update/src/wgpu.zig
@@ -2070,7 +2070,11 @@ pub const Queue = *opaque {
     }
 
     pub fn submit(queue: Queue, commands: []const CommandBuffer) void {
-        c.wgpuQueueSubmit(@ptrCast(queue), @as(u32, @intCast(commands.len)), commands.ptr);
+        c.wgpuQueueSubmit(
+            @ptrCast(queue),
+            @as(usize, @intCast(commands.len)),
+            @ptrCast(commands.ptr),
+        );
     }
 
     pub fn writeBuffer(

--- a/zig-gamedev-zgpu-dawn-update/src/zgpu.zig
+++ b/zig-gamedev-zgpu-dawn-update/src/zgpu.zig
@@ -453,8 +453,15 @@ pub const GraphicsContext = struct {
         gctx.uniformsNextStagingBuffer();
     }
 
-    fn uniformsMappedCallback(status: wgpu.BufferMapAsyncStatus, userdata: ?*anyopaque) callconv(.C) void {
-        const usb = @as(*UniformsStagingBuffer, @ptrCast(@alignCast(userdata)));
+    fn uniformsMappedCallback(
+        status: wgpu.MapAsyncStatus,
+        message: wgpu.StringView.C,
+        userdata_1: ?*anyopaque,
+        userdata_2: ?*anyopaque,
+    ) callconv(.C) void {
+        _ = message;
+        _ = userdata_2;
+        const usb = @as(*UniformsStagingBuffer, @ptrCast(@alignCast(userdata_1)));
         assert(usb.slice == null);
         if (status == .success) {
             usb.slice = usb.buffer.getMappedRange(u8, 0, uniforms_buffer_size).?;
@@ -468,12 +475,14 @@ pub const GraphicsContext = struct {
             // Map staging buffer which was used this frame.
             const current = gctx.uniforms.stage.current;
             assert(gctx.uniforms.stage.buffers[current].slice == null);
-            gctx.uniforms.stage.buffers[current].buffer.mapAsync(
+            _ = gctx.uniforms.stage.buffers[current].buffer.mapAsync(
                 .{ .write = true },
                 0,
                 uniforms_buffer_size,
-                uniformsMappedCallback,
-                @ptrCast(&gctx.uniforms.stage.buffers[current]),
+                .{
+                    .callback = uniformsMappedCallback,
+                    .userdata_1 = @ptrCast(&gctx.uniforms.stage.buffers[current]),
+                },
             );
         }
 
@@ -490,8 +499,6 @@ pub const GraphicsContext = struct {
         if (gctx.uniforms.stage.num >= uniforms_staging_pipeline_len) {
             // Wait until one of the buffers is mapped and ready to use.
             while (true) {
-                gctx.device.tick();
-
                 i = 0;
                 while (i < gctx.uniforms.stage.num) : (i += 1) {
                     if (gctx.uniforms.stage.buffers[i].slice != null) {
@@ -511,7 +518,7 @@ pub const GraphicsContext = struct {
         const buffer_handle = gctx.createBuffer(.{
             .usage = .{ .copy_src = true, .map_write = true },
             .size = uniforms_buffer_size,
-            .mapped_at_creation = .true,
+            .mapped_at_creation = c.WGPU_TRUE,
         });
 
         // Add new (mapped) staging buffer to the buffer list.
@@ -562,11 +569,18 @@ pub const GraphicsContext = struct {
         gctx.uniformsNextStagingBuffer();
     }
 
-    fn gpuWorkDone(status: wgpu.QueueWorkDoneStatus, userdata: ?*anyopaque) callconv(.C) void {
-        const gpu_frame_number: *u64 = @ptrCast(@alignCast(userdata));
+    fn gpuWorkDone(
+        status: wgpu.QueueWorkDoneStatus,
+        message: wgpu.StringView.C,
+        userdata_1: ?*anyopaque,
+        userdata_2: ?*anyopaque,
+    ) callconv(.C) void {
+        _ = message;
+        _ = userdata_2;
+        const gpu_frame_number: *u64 = @ptrCast(@alignCast(userdata_1));
         gpu_frame_number.* += 1;
         if (status != .success) {
-            std.log.err("[zgpu] Failed to complete GPU work (status: {s}).", .{@tagName(status)});
+            std.log.err("[zgpu] Failed to complete GPU work (status: {s}).", .{ @tagName(status) });
         }
     }
 
@@ -680,6 +694,7 @@ pub const GraphicsContext = struct {
         // if (!emscripten and dim == .undefined) {
         if (dim == .undefined) {
             dim = switch (info.dimension) {
+                .undefined => .tvdim_2d,
                 .tdim_1d => .tvdim_1d,
                 .tdim_2d => .tvdim_2d,
                 .tdim_3d => .tvdim_3d,


### PR DESCRIPTION
## Summary
- update queue submission pointer casting
- adjust buffer mapping callback signatures and API calls
- update GPU work completion callback signature
- handle undefined texture dimensions and proper buffer flags
- remove obsolete device.tick call

## Testing
- `zig build test` *(fails: undefined symbols)*

------
https://chatgpt.com/codex/tasks/task_e_687600e14348832e9b0c876aa32551da